### PR TITLE
Added inline Table of Contents

### DIFF
--- a/docs/multisig-DAO/create-multisig-DAO/DAO-wizard.md
+++ b/docs/multisig-DAO/create-multisig-DAO/DAO-wizard.md
@@ -23,6 +23,8 @@ Then, your wallet will pop up asking to connect to the app. Click connect and yo
 
 ![connectwallet](/img/multisig-DAO/connect-wallet.png)
 
+### DAO Wizard Page
+
 The DAO Wizard is a feature to help you with the setup of your DAO. It will guide you through the necessary steps to create a new DAO.
 In the wizard page, it's possible to choose between two options:
 

--- a/docs/multisig-DAO/create-multisig-DAO/multisig-DAO.md
+++ b/docs/multisig-DAO/create-multisig-DAO/multisig-DAO.md
@@ -16,6 +16,10 @@ So, let's create a multisig DAO together.
 
 ---
 
+## Creating the DAO
+
+### Multisig DAO setup
+
 1. **Click on `I want to create a multisig DAO` option and the following form will be shown:**
 
 ![multisiformempty](/img/multisig-DAO/multisig-form-empty.png)
@@ -45,6 +49,9 @@ Note that you can place as many wallets you want, one per line.
 :::danger Remember
 The current connected wallet is required. If it is not automatically included in the members list, include it or the transaction will result in an error.
 :::
+
+### Check & Create
+
 **After following this steps, you should have something like the image below:**
 ![multisigteam](/img/multisig-DAO/multisig-form.png)
 


### PR DESCRIPTION
Added inline Table of Contents for better readability and separation between steps. Also, to allow UI to look cleaner compared to other pages.

Added it in "Create a Multisig DAO" page and "DAO Wizard" page table of contents (right side):

Before:
![DAOWizardBefore](https://user-images.githubusercontent.com/59552589/154202864-61ae758a-b5a4-4dbb-9b97-7e98cf77539e.png)
After:
![DAOWizardAfter](https://user-images.githubusercontent.com/59552589/154202870-988a65fc-3487-4ded-825f-939b66fb7b85.png)

Before:
![MultisigBefore](https://user-images.githubusercontent.com/59552589/154202879-f3378f9f-9348-4cc4-a3cb-109555ce927d.png)
After
![MultisigAfter](https://user-images.githubusercontent.com/59552589/154202876-f1c38d4b-60f9-4e1b-8744-7beb28f643cd.png)

